### PR TITLE
Update Chart.js values when percentage is updated.

### DIFF
--- a/GaugeChart.vue
+++ b/GaugeChart.vue
@@ -64,19 +64,10 @@ export default {
       return Math.ceil(this.max * this.last);
     },
     percentage() {
-      return (this.last * 100).toFixed(0);
-    }
-  },
-  watch: {
-    last(latest) {
-      this.last = Number(latest).toFixed(2);
-      if(!latest) {
-        return false;
-      }
-      const [values] = this.chart.data.datasets;
-      const next = [this.last, (1 - this.last).toFixed(2)];
-      values.data = next;
-      this.chart.update();
+      // note: this computed property updates both the html and the canvas data
+      // this will only continue to update if percentage is in the template
+      this.setChartData(this.last);
+      return Math.ceil(this.last * 100);
     }
   },
   mounted() {
@@ -105,6 +96,18 @@ export default {
         }
       }
     });
+  },
+  methods: {
+    setChartData(latest) {
+      if(!latest || !this.chart) {
+        return false;
+      }
+      this.last = Number(latest).toFixed(2);
+      const [values] = this.chart.data.datasets;
+      const next = [this.last, (1 - this.last).toFixed(2)];
+      values.data = next;
+      this.chart.update();
+    }
   }
 };
 </script>

--- a/GaugeChart.vue
+++ b/GaugeChart.vue
@@ -64,10 +64,13 @@ export default {
       return Math.ceil(this.max * this.last);
     },
     percentage() {
-      // note: this computed property updates both the html and the canvas data
-      // this will only continue to update if percentage is in the template
-      this.setChartData(this.last);
       return Math.ceil(this.last * 100);
+    }
+  },
+  watch: {
+    last: {
+      handler(newVal, oldVal) {this.setChartData(newVal || oldVal);},
+      immediate: true
     }
   },
   mounted() {
@@ -96,6 +99,7 @@ export default {
         }
       }
     });
+    this.setChartData(this.last);
   },
   methods: {
     setChartData(latest) {
@@ -103,9 +107,8 @@ export default {
         return false;
       }
       this.last = Number(latest).toFixed(2);
-      const [values] = this.chart.data.datasets;
       const next = [this.last, (1 - this.last).toFixed(2)];
-      values.data = next;
+      this.chart.data.datasets[0].data = next;
       this.chart.update();
     }
   }

--- a/GaugeChart.vue
+++ b/GaugeChart.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="relative gauge-holder">
-    <canvas ref="chart" />
+    <canvas
+      ref="chart"
+      :data="chartData" />
     <div class="absolute-center text-center">
       <p class="percent-holder">
         <span
@@ -65,12 +67,9 @@ export default {
     },
     percentage() {
       return Math.ceil(this.last * 100);
-    }
-  },
-  watch: {
-    last: {
-      handler(newVal, oldVal) {this.setChartData(newVal || oldVal);},
-      immediate: true
+    },
+    chartData() {
+      return this.setChartData(this.last);
     }
   },
   mounted() {

--- a/GaugeChart.vue
+++ b/GaugeChart.vue
@@ -109,6 +109,7 @@ export default {
       const next = [this.last, (1 - this.last).toFixed(2)];
       this.chart.data.datasets[0].data = next;
       this.chart.update();
+      return true;
     }
   }
 };

--- a/TimeSeriesChart.vue
+++ b/TimeSeriesChart.vue
@@ -117,11 +117,7 @@ export default {
   },
   watch: {
     series(newSeries) {
-      newSeries.forEach(p => {
-        p.y = p.y.toFixed(2);
-        this.chart.data.datasets[0].data.push(p);
-      });
-      this.chart.update();
+      this.updateSeries(newSeries);
     },
     max(newMax, oldMax) {
       if(newMax !== oldMax) {
@@ -182,6 +178,13 @@ export default {
     this.updateMax(this.max);
   },
   methods: {
+    updateSeries(newSeries) {
+      newSeries.forEach(p => {
+        p.y = Number(p.y).toFixed(2);
+        this.chart.data.datasets[0].data.push(p);
+      });
+      this.chart.update();
+    },
     pause() {
       const [axis] = this.chart.options.scales.xAxes;
       this.paused = !this.paused;

--- a/TimeSeriesChart.vue
+++ b/TimeSeriesChart.vue
@@ -120,9 +120,7 @@ export default {
       this.updateSeries(newSeries);
     },
     max(newMax, oldMax) {
-      if(newMax !== oldMax) {
-        this.updateMax(newMax);
-      }
+      this.updateMax(newMax || oldMax);
     }
   },
   mounted() {
@@ -179,6 +177,9 @@ export default {
   },
   methods: {
     updateSeries(newSeries) {
+      if(!this.chart) {
+        return null;
+      }
       newSeries.forEach(p => {
         p.y = Number(p.y).toFixed(2);
         this.chart.data.datasets[0].data.push(p);

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -44,9 +44,10 @@
 'use strict';
 
 // FIXME: chartjs is loaded as a global in index.js as a hack
-import {ChartController} from 'bedrock-web-stats';
+import {statsService, ChartController} from 'bedrock-web-stats';
 import {BrGaugeChart, BrTimeSeriesChart} from 'bedrock-vue-stats';
 import staticSeries from '../mocks/staticSeries.json';
+import units from './units';
 
 export default {
   name: 'Home',
@@ -71,18 +72,20 @@ export default {
     this.$set(this, 'cpu', new ChartController(
       {
         type: 'pie',
+        statsService,
         format: {
-          prefix({last}) {return last.monitors.os.currentLoad;},
+          prepare({latest}) {return latest.monitors.os.currentLoad;},
           last(p) {return p.avgload;},
           max(p) {return p.cpus.length;}
         }}));
     this.$set(this, 'ramseries', new ChartController(
       {
         type: 'realtime',
+        statsService,
         format: {
-          prefix({latest}) {return latest.map(r => r.monitors.os.mem);},
-          y(p) {return p.active / this.units.gb;},
-          max(p) {return p.total / this.units.gb;}
+          prepare({latest}) {return latest.monitors.os.mem;},
+          y(p) {return p.active / units.gb;},
+          max(p) {return p.total / units.gb;}
         }}));
 
   },

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -15,16 +15,6 @@
       </span>
     </div>
     <div>
-      <h4>Static Line Chart</h4>
-      <br-time-series-chart
-        id="static-chart"
-        :line="colors().line"
-        :fill="colors(0.8).disk"
-        :max="8"
-        :series="staticSeries"
-        label="Static Example" />
-    </div>
-    <div>
       <h4>Real time Line Chart </h4>
       <br-time-series-chart
         id="mem-used"
@@ -34,6 +24,16 @@
         :series="ramseries.chart.series"
         realtime
         label="RAM Usage GB" />
+    </div>
+    <div>
+      <h4>Static Line Chart</h4>
+      <br-time-series-chart
+        id="static-chart"
+        :line="colors().line"
+        :fill="colors(0.8).disk"
+        :max="8"
+        :series="staticSeries"
+        label="Static Example" />
     </div>
   </q-page>
 </template>

--- a/test/components/units.js
+++ b/test/components/units.js
@@ -1,0 +1,10 @@
+const units = {
+  /**
+   * Units such as gigabytes that the stats needed to be formatted in.
+   * @typedef ChartUnit
+   * @property {number} gb - the number of bytes in a gigabyte.
+  */
+  gb: Math.pow(2, 30)
+};
+
+export default units;


### PR DESCRIPTION
@davidlehn this should correct the bug you found. Sorry about the bug, but Vue's update cycle is harder to manage when the data is in a canvas object rather than in html. Basically props and data used in Vue templates lead to snappy updates, in this case the data is hidden inside an html canvas which vue does not see leading to delays in updates. It turns out watch was not firing until the cpu.chart.last value changed from the initial value which means the chart was just sitting there.

Should fix:
https://github.com/digitalbazaar/bedrock-vue-stats/issues/3

Please do try this and let me know if it works to your specifications.

just so you know this is not the only way to fix this:

https://vuejs.org/v2/api/#vm-watch

it turns out watch has an immediate option that when set to true I believe results in the first update triggering watch.

_NOTE: this PR depends on bedrock-web-stats branch which is still in development so this might be broken until ChartController and StatsService are finalized._