### PR TITLE
Upgrade chart.js and plugin.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "browserDependencies": "all"
   },
   "dependencies": {
-    "chart.js": "2.7.3",
-    "chartjs-plugin-streaming": "1.7.1"
+    "chart.js": "2.8.0",
+    "chartjs-plugin-streaming": "1.8.0"
   },
   "devDependencies": {
     "eslint": "^5.15.1",

--- a/test/package.json
+++ b/test/package.json
@@ -20,6 +20,7 @@
     "bedrock-karma": "^1.0.0",
     "bedrock-key": "^5.1.2",
     "bedrock-mongodb": "^5.5.0",
+    "bedrock-package-manager": "^1.0.0",
     "bedrock-passport": "^4.0.4",
     "bedrock-permission": "^2.5.3",
     "bedrock-quasar": "^1.0.0",

--- a/test/package.json
+++ b/test/package.json
@@ -16,7 +16,7 @@
     "bedrock-did-client": "^1.1.2",
     "bedrock-express": "^2.0.6",
     "bedrock-identity": "^6.1.0",
-    "bedrock-jobs": "github:digitalbazaar/bedrock-jobs#3.x",
+    "bedrock-jobs": "github:digitalbazaar/bedrock-jobs",
     "bedrock-karma": "^1.0.0",
     "bedrock-key": "^5.1.2",
     "bedrock-mongodb": "^5.5.0",


### PR DESCRIPTION
chartjs-plugin-streaming updated and the update appears to be stable.
This means chart.js 2.8 can now be used stably with the project.

Here is what we get:

https://github.com/chartjs/Chart.js/releases/tag/v2.8.0

the update for the plugin appears to be purely just to get it to work chart.js 2.8.0:

https://github.com/nagix/chartjs-plugin-streaming/releases/tag/v1.8.0